### PR TITLE
Replaced scheduleDelayedTask():

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Easily create fake inventories that players can interact with.
         if (provider == null || provider.getProvider() == null) {
             this.getServer().getPluginManager().disablePlugin(this);
         }
-        
-        ...
     }
 ``` 
 
@@ -23,8 +21,8 @@ Easily create fake inventories that players can interact with.
 ```xml
     <repositories>
         <repository>
-            <id>nukkitx-repo</id>
-            <url>https://repo.nukkitx.com/snapshot/</url>
+            <id>NukkitX-repo</id>
+            <url>https://repo.opencollab.dev/</url>
         </repository>
     </repositories>
 
@@ -32,7 +30,7 @@ Easily create fake inventories that players can interact with.
         <dependency>
             <groupId>com.nukkitx</groupId>
             <artifactId>fakeinventories</artifactId>
-            <version>1.0.2</version>
+            <version>1.0.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.nukkitx</groupId>
     <artifactId>fakeinventories</artifactId>
     <name>Fake Inventories</name>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -19,48 +19,52 @@
 
     <organization>
         <name>NukkitX</name>
-        <url>https://github.com/FakeInventories</url>
+        <url>https://github.com/CloudburstMC</url>
     </organization>
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/NukkitX/FakeInventories/issues</url>
+        <url>https://github.com/CloudburstMC/FakeInventories/issues</url>
     </issueManagement>
 
     <ciManagement>
         <system>Jenkins</system>
-        <url>https://ci.nukkitx.com/job/NukkitX/job/FakeInventories</url>
+        <url>https://ci.opencollab.dev/job/NukkitX/job/FakeInventories/</url>
     </ciManagement>
 
     <scm>
-        <connection>scm:git:https://github.com/NukkitX/FakeInventories.git</connection>
-        <developerConnection>scm:git:git@github.com:NukkitX/FakeInventories.git</developerConnection>
-        <url>https://github.com/NukkitX/FakeInventories</url>
+        <connection>scm:git:https://github.com/CloudburstMC/FakeInventories.git</connection>
+        <developerConnection>scm:git:git@github.com:CloudburstMC/FakeInventories.git</developerConnection>
+        <url>https://github.com/CloudBurstMC/FakeInventories</url>
     </scm>
 
     <distributionManagement>
         <repository>
             <id>releases</id>
             <name>nukkitx-releases</name>
-            <url>https://repo.nukkitx.com/release</url>
+            <url>https://repo.opencollab.dev/maven-releases</url>
         </repository>
         <snapshotRepository>
             <id>snapshots</id>
             <name>nukkitx-snapshots</name>
-            <url>https://repo.nukkitx.com/snapshot</url>
+            <url>https://repo.opencollab.dev/maven-snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>
         <repository>
-            <id>nukkitx-repo</id>
-            <url>https://repo.nukkitx.com/snapshot/</url>
+            <id>nukkitx-releases</id>
+            <url>https://repo.opencollab.dev/maven-releases</url>
+        </repository>
+        <repository>
+            <id>nukkitx-snapshots</id>
+            <url>https://repo.opencollab.dev/maven-snapshots</url>
         </repository>
     </repositories>
 

--- a/src/main/java/com/nukkitx/fakeinventories/FakeInventoriesPlugin.java
+++ b/src/main/java/com/nukkitx/fakeinventories/FakeInventoriesPlugin.java
@@ -5,10 +5,22 @@ import cn.nukkit.plugin.service.ServicePriority;
 import com.nukkitx.fakeinventories.inventory.FakeInventories;
 
 public class FakeInventoriesPlugin extends PluginBase {
+    // Static reference to the plugin instance
+    private static FakeInventoriesPlugin instance;
+
+    // FakeInventories instance
     private final FakeInventories fakeInventories = new FakeInventories();
+
+    // Getter to retrieve the plugin instance globally
+    public static FakeInventoriesPlugin getInstance() {
+        return instance;
+    }
 
     @Override
     public void onEnable() {
+        // Store the instance of this plugin to be accessed globally
+        instance = this;
+
         // register service
         getServer().getServiceManager().register(FakeInventories.class, fakeInventories, this, ServicePriority.HIGHEST);
 

--- a/src/main/java/com/nukkitx/fakeinventories/inventory/DoubleChestFakeInventory.java
+++ b/src/main/java/com/nukkitx/fakeinventories/inventory/DoubleChestFakeInventory.java
@@ -9,6 +9,8 @@ import cn.nukkit.math.BlockVector3;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.network.protocol.BlockEntityDataPacket;
+import com.nukkitx.fakeinventories.FakeInventoriesPlugin;
+import cn.nukkit.scheduler.NukkitRunnable;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -29,7 +31,6 @@ public class DoubleChestFakeInventory extends ChestFakeInventory {
         super(InventoryType.DOUBLE_CHEST, holder, title);
     }
 
-
     @Override
     public void onOpen(Player who) {
         this.viewers.add(who);
@@ -37,9 +38,13 @@ public class DoubleChestFakeInventory extends ChestFakeInventory {
         List<BlockVector3> blocks = onOpenBlock(who);
         blockPositions.put(who, blocks);
 
-        Server.getInstance().getScheduler().scheduleDelayedTask(() -> {
-            onFakeOpen(who, blocks);
-        }, 3);
+        // Use NukkitRunnable to schedule the task
+        new NukkitRunnable() {
+            @Override
+            public void run() {
+                onFakeOpen(who, blocks);
+            }
+        }.runTaskLater(FakeInventoriesPlugin.getInstance(), 3);  // Use globally accessible plugin instance
     }
 
     @Override


### PR DESCRIPTION
I replaced the deprecated task scheduling method with NukkitRunnable.
The task is scheduled using NukkitRunnable.runTaskLater(), which is better supported and cleaner. 

Global Plugin Access:
The globally accessible Plugin instance is fetched using FakeInventoriesPlugin.getInstance() to ensure that the task is tied to the correct plugin lifecycle.

Also version bump though this wont break anything.